### PR TITLE
v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dependencies": {
         "@chatscope/chat-ui-kit-react": "^2.0.3",
         "@chatscope/chat-ui-kit-styles": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Changes since v1.0.0

### Auth refactor — per-app session cookies

The shared `session` cookie was replaced with per-app cookies (`session-plants`, `session-political-culture`, `session-cfflch`). All session functions (`getSession`, `createSession`, `updateSession`, `verifySession`, `deleteSession`) now accept a `cookieName` argument. `useSession` now takes an `appName` argument and constructs the cookie name internally.

Each app got its own `actions/login.ts` (previously there was a single shared one at `src/app/actions/login.ts`, which was deleted). The shared `login.ts` had no concept of which app was calling it — the per-app versions hit the correct backend endpoint and pass the right cookie name to `createSession`.

The middleware was updated to derive the cookie name from the matched project key, so auth checks are isolated per app.

---

### Middleware — app-aware routing

The `PROJECTS` map in `middleware.ts` is now the single place that defines routing rules per app. `cfflch` was registered with public path `""` (login) and protected paths `search` and `results`.

---

### cfflch — new app (frontend)

The entire `cfflch` app was built from scratch:

- **Login** — `LoginForm` + `login` server action, standard pattern matching plants and political-culture
- **Layout** — MUI `Drawer` navigation with links to `/cfflch/search` and `/cfflch/results`; dark theme via `layout.css`
- **Search page** — `SearchForm` takes student names (multiline), year, and optional class; connects a WebSocket on mount before triggering the POST (backend constraint); streams results in real time via `useAdmissionSearch` hook
- **Results page** — `ResultsTable` fetches saved admission results with year, PDF, and class filters; `ResultCard` handles per-record approved toggle, classroom assignment, and delete — all via PATCH/DELETE to the backend
- **Types** — `PdfUrl`, `ClassRoom`, `SavedAdmissionResult`

The landing page (`src/app/page.tsx`) was updated with a link to `/cfflch`.

---

### Plants — minor fixes

- `LoginForm` now imports `login` from `@/plants/actions/login` instead of the deleted shared action; `setSubmitting(false)` was added after a successful login before the redirect
- `MuiDrawer` responsive padding syntax was simplified from a raw media query string to the MUI `sm` breakpoint token

---

### Results page — mobile layout

`.result-card-header` and `.result-card-actions` were given `flex-wrap: wrap` so the actions row drops below the student name on narrow screens instead of overflowing. The student name got `word-break: break-word` for long names. Container padding reduces from `2rem` to `1rem` at ≤600px.
